### PR TITLE
Better "WORD" logo formatting

### DIFF
--- a/Source/Fasetto.Word/MainWindow.xaml
+++ b/Source/Fasetto.Word/MainWindow.xaml
@@ -90,7 +90,10 @@
                                         <Viewbox Grid.Column="0" Grid.ColumnSpan="3" Margin="5">
                                             <StackPanel>
                                                 <TextBlock FontFamily="{StaticResource LatoBold}" FontSize="{StaticResource FontSizeLarge}" Margin="0,0,0,-5">
-                                                    <Run Text="W" Foreground="{StaticResource WordOrangeBrush}" /><Run Text="O" Foreground="{StaticResource WordBlueBrush}" /><Run Text="R" Foreground="{StaticResource WordRedBrush}" /><Run Text="D" Foreground="{StaticResource WordGreenBrush}" />
+                                                    <Run Text="W" Foreground="{StaticResource WordOrangeBrush}" /><!--
+                                                    --><Run Text="O" Foreground="{StaticResource WordBlueBrush}" /><!--
+                                                    --><Run Text="R" Foreground="{StaticResource WordRedBrush}" /><!--
+                                                    --><Run Text="D" Foreground="{StaticResource WordGreenBrush}" />
                                                 </TextBlock>
                                                 <TextBlock Text="by fasetto" Foreground="{StaticResource ForegroundDarkBrush}" TextAlignment="Center" />
                                             </StackPanel>


### PR DESCRIPTION
Changed the long line at the "WORD" logo into 4 more readable lines using comments to escape the white spaces.

Sorry for the previous pull request, still new to this things. 
