### PR TITLE
fix: ItemAutomationPeer NullReferenceException

### DIFF
--- a/Source/Fasetto.Word/Dialogs/BaseDialogUserControl.cs
+++ b/Source/Fasetto.Word/Dialogs/BaseDialogUserControl.cs
@@ -117,7 +117,7 @@ namespace Fasetto.Word
                     // Let caller know we finished
                     tcs.TrySetResult(true);
                 }
-            });
+            }, System.Windows.Threading.DispatcherPriority.ApplicationIdle);
 
             return tcs.Task;
         }


### PR DESCRIPTION
In my case, if i run the application with a open Skype presentation. Throws the PresentationFramework.dll a NullReferenceException in the method ItemAutomationPeer.GetNameCore(). The changing of the DispatcherPriority to ApplicationIdle fixed the problem.